### PR TITLE
Create KTXTools.md

### DIFF
--- a/KTXTools.md
+++ b/KTXTools.md
@@ -1,0 +1,26 @@
+# KTX 2.0 tools
+
+[KTX-Software](https://github.com/KhronosGroup/KTX-Software/) provides official C/C++/WASM libraries for reading, writing, and transcoding KTX files, Includes [downloadable binary packages](https://github.com/KhronosGroup/KTX-Software/releases).
+
+*For other projects intended for specific tasks related to KTX 2.0, see functional sections below.*
+
+## Read/Write KTX textures
+
+- [KTX-Parse](https://github.com/donmccurdy/KTX-Parse): Lightweight JavaScript/TypeScript/Node.js library for reading and writing KTX files. Transcoding to a GPU compressed format must be handled separately.
+
+## Transcode KTX to GPU formats
+
+- [Binomial Transcoders](https://github.com/BinomialLLC/basis_universal): Official C/C++ and WASM transcoders, for all Basis input formats and transcoding targets.
+- [Khronos Transcoders](https://github.com/KhronosGroup/Basis-Universal-Transcoders): Lightweight WASM transcoders, for selected Basis input formats and transcoding targets.
+
+## View KTX textures
+
+- [BabylonJS Sandbox](https://sandbox.babylonjs.com/): allows users to view standalone KTX textures, or glTF models using embedded KTX textures.
+- [Gestaltor Editor](https://gestaltor.io/): Visual glTF editor with KTX read/write support.
+
+## KTX textures in glTF 3D models
+
+- [Gestaltor Editor](https://gestaltor.io/): Visual glTF editor with KTX read/write support.
+- [gltf-transform](https://gltf-transform.donmccurdy.com/cli.html): CLI tool that allows converting a glTF model’s textures to KTX.
+- [gltfpack](https://github.com/zeux/meshoptimizer/tree/master/gltf): CLI tool that allows converting a glTF model’s textures to KTX.
+- [RapidCompact](https://rapidcompact.com/): Online platform for optimization of 3D data.


### PR DESCRIPTION
Proposed KTX Tools page. Please review for correctness, not completeness, or make [suggested changes](https://haacked.com/archive/2019/06/03/suggested-changes/) for additions. 

This overlaps somewhat with the KTX-Software Wiki (https://github.com/KhronosGroup/KTX-Software/wiki). My preference is that a markdown file in this repo will be more accessible and maintainable for the community. Is that okay?
